### PR TITLE
[FIX] fix typo in variable name

### DIFF
--- a/connector_office_365_hr_leave/models/calendar_event.py
+++ b/connector_office_365_hr_leave/models/calendar_event.py
@@ -18,5 +18,5 @@ class CalendarEvent(models.Model):
                 values['subject'] = '{} - {}'.format(
                     values['subject'], leave.name
                 )
-        values['ShowAs'] = 'oof'
+        values['showAs'] = 'oof'
         return values


### PR DESCRIPTION
* Purpose *
My previous fix have a type, so we have 2 tags showas in the json