### PR TITLE
[IMP] error handling

### DIFF
--- a/connector_office_365/__init__.py
+++ b/connector_office_365/__init__.py
@@ -1,2 +1,5 @@
 from . import models
 from . import controllers
+
+
+Office365Error = models.res_users.Office365Error


### PR DESCRIPTION
* use a specific exception class (Office365Error) when API call fails
* when deleting a calendar event in Odoo, don't block if the removal fails on
Office. This can happen if the meeting was already deleted in Office.

I wish we had a better way of detecting the 'already deleted' case. Maybe there is an
error code in the message returned from the API? I would like to avoid string matching,
as this is generally locale dependent...